### PR TITLE
Chaz search detail fix

### DIFF
--- a/BangazonWeb/Views/Products/Search.cshtml
+++ b/BangazonWeb/Views/Products/Search.cshtml
@@ -37,7 +37,7 @@
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Name)
+                  <a asp-controller="Products" asp-action="Details" asp-route-id="@item.ProductID"> @Html.DisplayFor(modelItem => item.Name) </a>
                 </td>
                 <td>
                     @Html.DisplayFor(modelItem => item.Description)

--- a/BangazonWeb/Views/Shared/_Layout.cshtml
+++ b/BangazonWeb/Views/Shared/_Layout.cshtml
@@ -39,7 +39,7 @@
                     <div class="radio">
                         <label class="nav_radio_text">
 
-                            <input type="radio" name ="SearchRadio" value="products" class="nav_radio_text"> Search Products
+                            <input type="radio" name ="SearchRadio" value="products" class="nav_radio_text" checked="checked"> Search Products
 
                         </label>
                     </div>


### PR DESCRIPTION
## REFERENCE

Ticket: #4 

## DESCRIPTION
Edited the search results view. 
Now products should have have a link to the product details view. 
Also "Products" is now the default when searching

## STEPS TO TEST
1.Search for a product. "Product" should be selected by default, but "Location" is also available
1. When searching for a product, click on the product name and it should take you to that products detail view. 
